### PR TITLE
Hotfix test threshold heatmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/settings.json
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/settings.json
 *.pyc
+.vscode/launch.json

--- a/tests/test_threshold_heatmap.py
+++ b/tests/test_threshold_heatmap.py
@@ -14,25 +14,33 @@ import matplotlib.colors as mcolors
 from matplotlib.colors import ListedColormap
 import scanpy as sc
 import unittest
+from unittest.mock import MagicMock
 
 class TestThresholdHeatmap(unittest.TestCase):
 
     def setUp(self):
-        # Create a mock anndata object
-        self.adata = MagicMock()
-        self.adata.obs_names = ['cell1', 'cell2', 'cell3']
-        self.adata.obs = pd.DataFrame({'phenotype': ['A', 'B', 'A']}, index=self.adata.obs_names)
-        self.adata[:, 'marker1'].X = np.array([[0.1], [0.5], [1.0]])
-        self.adata[:, 'marker2'].X = np.array([[0.3], [0.7], [1.5]])
+        
+        self.obs_names = ['cell1', 'cell2', 'cell3']
+        self.obs = pd.DataFrame({'phenotype': ['A', 'B', 'A']}, index=self.obs_names)
+        self.X = np.array([[0.1, 0.3], [0.5, 0.7], [1.0, 1.5]])
+        self.var_names = ['marker1', 'marker2']
+        self.var = pd.DataFrame(index=self.var_names)
+
+        self.adata = anndata.AnnData(X=self.X, obs=self.obs, var=self.var)
+        self.adata.obs_names = self.obs_names
+        self.adata.var_names = self.var_names
+
         
         self.marker_cutoffs = {
             'marker1': (0.2, 0.8),
             'marker2': (0.4, 1.0),
         }
 
+
         self.phenotype = 'phenotype'
 
     def test_threshold_heatmap(self):
+        
         fig = threshold_heatmap(self.adata, self.marker_cutoffs, self.phenotype)
         
         # Check if the figure object is returned


### PR DESCRIPTION
The origin method uses the magic mock, which does not have the anndata.obs_name field, leading to failure of unitest.